### PR TITLE
Add renderer logic and Windows build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# demo-recorder
-Electron app to record screen + mic and export developer demo videos
+# Demo Recorder
+
+Demo Recorder is a free Electron based desktop application for Windows, macOS and Linux that allows teams and developers to quickly capture screen recordings with optional audio. The project aims to provide a simple alternative to commercial tools like Focusee or Rapidemo.
+
+## Getting Started
+
+1. Install [Node.js](https://nodejs.org/) 18 or later.
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Run the app in development mode:
+   ```bash
+   npm start
+   ```
+
+## Building for Windows
+
+To create a Windows installer, run:
+
+```bash
+npm run dist
+```
+
+The packaged installer will be available in the `dist/` directory.
+
+## Features
+
+- Select any window or screen as the recording source
+- Record in WebM format with optional audio
+- Preview the capture before recording
+- Pause and resume during recording
+
+Contributions are welcome!

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -1,0 +1,81 @@
+const { ipcRenderer } = require('electron');
+
+let mediaRecorder;
+let recordedChunks = [];
+let selectedSourceId = null;
+
+async function loadSources() {
+  const sources = await ipcRenderer.invoke('get-sources');
+  const grid = document.getElementById('source-grid');
+  grid.innerHTML = '';
+  sources.forEach((source) => {
+    const btn = document.createElement('button');
+    btn.classList.add('source-item');
+    btn.innerHTML = `<img src="${source.thumbnail.toDataURL()}" />${source.name}`;
+    btn.addEventListener('click', () => selectSource(source.id));
+    grid.appendChild(btn);
+  });
+}
+
+async function selectSource(sourceId) {
+  selectedSourceId = sourceId;
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: false,
+    video: {
+      mandatory: {
+        chromeMediaSource: 'desktop',
+        chromeMediaSourceId: sourceId
+      }
+    }
+  });
+  const video = document.getElementById('preview-video');
+  video.srcObject = stream;
+  video.play();
+
+  const options = { mimeType: 'video/webm; codecs=vp9' };
+  recordedChunks = [];
+  mediaRecorder = new MediaRecorder(stream, options);
+  mediaRecorder.ondataavailable = (e) => recordedChunks.push(e.data);
+  mediaRecorder.onstop = handleStop;
+
+  document.getElementById('start-recording').disabled = false;
+}
+
+function startRecording() {
+  if (!mediaRecorder) return;
+  mediaRecorder.start();
+  document.getElementById('status-text').textContent = 'Recording';
+  document.getElementById('pause-recording').disabled = false;
+  document.getElementById('stop-recording').disabled = false;
+}
+
+function pauseRecording() {
+  if (mediaRecorder.state === 'recording') {
+    mediaRecorder.pause();
+    document.getElementById('status-text').textContent = 'Paused';
+  } else if (mediaRecorder.state === 'paused') {
+    mediaRecorder.resume();
+    document.getElementById('status-text').textContent = 'Recording';
+  }
+}
+
+function stopRecording() {
+  mediaRecorder.stop();
+  document.getElementById('status-text').textContent = 'Processing...';
+  document.getElementById('pause-recording').disabled = true;
+  document.getElementById('stop-recording').disabled = true;
+}
+
+async function handleStop() {
+  const blob = new Blob(recordedChunks, { type: 'video/webm' });
+  const buffer = Buffer.from(await blob.arrayBuffer());
+  await ipcRenderer.invoke('save-recording', buffer, `Recording-${Date.now()}.webm`);
+  document.getElementById('status-text').textContent = 'Ready';
+}
+
+document.getElementById('refresh-sources').addEventListener('click', loadSources);
+document.getElementById('start-recording').addEventListener('click', startRecording);
+document.getElementById('pause-recording').addEventListener('click', pauseRecording);
+document.getElementById('stop-recording').addEventListener('click', stopRecording);
+
+loadSources();

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1,0 +1,66 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #f5f5f5;
+  color: #333;
+}
+
+header {
+  background: #222;
+  color: #fff;
+  padding: 10px;
+}
+
+.main-content {
+  display: flex;
+  padding: 10px;
+}
+
+.controls-panel {
+  width: 40%;
+  padding-right: 10px;
+}
+
+.preview-panel {
+  flex-grow: 1;
+}
+
+.source-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.source-item {
+  width: 100px;
+  height: 80px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 12px;
+}
+
+button {
+  cursor: pointer;
+}
+
+.preview-container {
+  border: 1px solid #ccc;
+  height: 360px;
+}
+
+.preview-container video {
+  width: 100%;
+  height: 100%;
+}
+
+.status-indicator {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: red;
+  margin-right: 5px;
+}


### PR DESCRIPTION
## Summary
- implement renderer process logic for selecting sources and recording
- add basic styles for the renderer UI
- document how to build the Windows installer

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: electron-builder not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845131fd6d083259b3f6cf25214e717