### PR TITLE
Refactor main process and add backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Demo Recorder is a free Electron based desktop application for Windows, macOS an
    ```bash
    npm start
    ```
+4. (Optional) Start the backend service:
+   ```bash
+   npm run backend
+   ```
 
 ## Building for Windows
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,14 @@
+const express = require('express');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(express.json());
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Backend service listening on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "electron . --dev",
     "build": "electron-builder",
     "dist": "electron-builder --publish=never",
-    "pack": "electron-builder --dir"
+    "pack": "electron-builder --dir",
+    "backend": "node backend/server.js"
   },
   "keywords": [
     "screen-recorder",
@@ -31,7 +32,8 @@
   },
   "dependencies": {
     "fluent-ffmpeg": "^2.1.2",
-    "node-screenshots": "^0.1.5"
+    "node-screenshots": "^0.1.5",
+    "express": "^4.18.2"
   },
   "build": {
     "appId": "com.chahalneema.demorecorder",

--- a/src/main.js
+++ b/src/main.js
@@ -1,168 +1,15 @@
-const { app, BrowserWindow, ipcMain, desktopCapturer, dialog, Menu } = require('electron');
-const path = require('path');
-const fs = require('fs');
+const { app, BrowserWindow, dialog } = require('electron');
+const createWindow = require('./main/window');
+const { registerHandlers, isRecording } = require('./main/ipcHandlers');
 
 let mainWindow;
-let isRecording = false;
 
-function createWindow() {
-  mainWindow = new BrowserWindow({
-    width: 1200,
-    height: 800,
-    webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: false,
-      enableRemoteModule: true
-    },
-    icon: path.join(__dirname, '../assets/icon.png'),
-    show: false
-  });
-
-  mainWindow.loadFile(path.join(__dirname, 'renderer/index.html'));
-
-  // Show window when ready
-  mainWindow.once('ready-to-show', () => {
-    mainWindow.show();
-  });
-
-  // Create application menu
-  const template = [
-    {
-      label: 'File',
-      submenu: [
-        {
-          label: 'New Recording',
-          accelerator: 'CmdOrCtrl+N',
-          click: () => {
-            mainWindow.webContents.send('menu-new-recording');
-          }
-        },
-        {
-          label: 'Open Recordings Folder',
-          click: () => {
-            mainWindow.webContents.send('menu-open-recordings');
-          }
-        },
-        { type: 'separator' },
-        {
-          label: 'Exit',
-          accelerator: process.platform === 'darwin' ? 'Cmd+Q' : 'Ctrl+Q',
-          click: () => {
-            app.quit();
-          }
-        }
-      ]
-    },
-    {
-      label: 'Recording',
-      submenu: [
-        {
-          label: 'Start Recording',
-          accelerator: 'F9',
-          click: () => {
-            mainWindow.webContents.send('menu-start-recording');
-          }
-        },
-        {
-          label: 'Stop Recording',
-          accelerator: 'F10',
-          click: () => {
-            mainWindow.webContents.send('menu-stop-recording');
-          }
-        },
-        {
-          label: 'Pause/Resume',
-          accelerator: 'F8',
-          click: () => {
-            mainWindow.webContents.send('menu-pause-recording');
-          }
-        }
-      ]
-    },
-    {
-      label: 'View',
-      submenu: [
-        { role: 'reload' },
-        { role: 'forceReload' },
-        { role: 'toggleDevTools' },
-        { type: 'separator' },
-        { role: 'resetZoom' },
-        { role: 'zoomIn' },
-        { role: 'zoomOut' },
-        { type: 'separator' },
-        { role: 'togglefullscreen' }
-      ]
-    },
-    {
-      label: 'Help',
-      submenu: [
-        {
-          label: 'About',
-          click: () => {
-            dialog.showMessageBox(mainWindow, {
-              type: 'info',
-              title: 'About Demo Recorder',
-              message: 'Demo Recorder v1.0.0',
-              detail: 'Free screen recording app for developers and teams\n\nBuilt with Electron and modern web technologies.'
-            });
-          }
-        }
-      ]
-    }
-  ];
-
-  const menu = Menu.buildFromTemplate(template);
-  Menu.setApplicationMenu(menu);
+function init() {
+  mainWindow = createWindow(app);
+  registerHandlers(mainWindow);
 }
 
-// IPC handlers
-ipcMain.handle('get-sources', async () => {
-  try {
-    const sources = await desktopCapturer.getSources({
-      types: ['window', 'screen'],
-      thumbnailSize: { width: 320, height: 180 }
-    });
-    return sources;
-  } catch (error) {
-    console.error('Error getting sources:', error);
-    return [];
-  }
-});
-
-ipcMain.handle('save-recording', async (event, buffer, fileName) => {
-  try {
-    const { filePath } = await dialog.showSaveDialog(mainWindow, {
-      defaultPath: fileName,
-      filters: [
-        { name: 'Videos', extensions: ['webm', 'mp4'] },
-        { name: 'All Files', extensions: ['*'] }
-      ]
-    });
-
-    if (filePath) {
-      fs.writeFileSync(filePath, buffer);
-      return { success: true, path: filePath };
-    }
-    return { success: false, cancelled: true };
-  } catch (error) {
-    console.error('Error saving recording:', error);
-    return { success: false, error: error.message };
-  }
-});
-
-ipcMain.handle('get-app-version', () => {
-  return app.getVersion();
-});
-
-ipcMain.on('recording-started', () => {
-  isRecording = true;
-});
-
-ipcMain.on('recording-stopped', () => {
-  isRecording = false;
-});
-
-app.whenReady().then(createWindow);
+app.whenReady().then(init);
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
@@ -172,13 +19,12 @@ app.on('window-all-closed', () => {
 
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow();
+    init();
   }
 });
 
-// Prevent closing during recording
 app.on('before-quit', (event) => {
-  if (isRecording) {
+  if (isRecording()) {
     event.preventDefault();
     dialog.showMessageBox(mainWindow, {
       type: 'warning',

--- a/src/main/ipcHandlers.js
+++ b/src/main/ipcHandlers.js
@@ -1,0 +1,58 @@
+const { desktopCapturer, ipcMain, dialog, app } = require('electron');
+const fs = require('fs');
+
+let recording = false;
+
+function registerHandlers(mainWindow) {
+  ipcMain.handle('get-sources', async () => {
+    try {
+      const sources = await desktopCapturer.getSources({
+        types: ['window', 'screen'],
+        thumbnailSize: { width: 320, height: 180 }
+      });
+      return sources;
+    } catch (error) {
+      console.error('Error getting sources:', error);
+      return [];
+    }
+  });
+
+  ipcMain.handle('save-recording', async (event, buffer, fileName) => {
+    try {
+      const { filePath } = await dialog.showSaveDialog(mainWindow, {
+        defaultPath: fileName,
+        filters: [
+          { name: 'Videos', extensions: ['webm', 'mp4'] },
+          { name: 'All Files', extensions: ['*'] }
+        ]
+      });
+
+      if (filePath) {
+        fs.writeFileSync(filePath, buffer);
+        return { success: true, path: filePath };
+      }
+      return { success: false, cancelled: true };
+    } catch (error) {
+      console.error('Error saving recording:', error);
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('get-app-version', () => {
+    return app.getVersion();
+  });
+
+  ipcMain.on('recording-started', () => {
+    recording = true;
+  });
+
+  ipcMain.on('recording-stopped', () => {
+    recording = false;
+  });
+}
+
+function isRecording() {
+  return recording;
+}
+
+module.exports = { registerHandlers, isRecording };

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -1,0 +1,93 @@
+const { Menu, dialog } = require('electron');
+
+function buildMenu(mainWindow, app) {
+  const template = [
+    {
+      label: 'File',
+      submenu: [
+        {
+          label: 'New Recording',
+          accelerator: 'CmdOrCtrl+N',
+          click: () => {
+            mainWindow.webContents.send('menu-new-recording');
+          }
+        },
+        {
+          label: 'Open Recordings Folder',
+          click: () => {
+            mainWindow.webContents.send('menu-open-recordings');
+          }
+        },
+        { type: 'separator' },
+        {
+          label: 'Exit',
+          accelerator: process.platform === 'darwin' ? 'Cmd+Q' : 'Ctrl+Q',
+          click: () => {
+            app.quit();
+          }
+        }
+      ]
+    },
+    {
+      label: 'Recording',
+      submenu: [
+        {
+          label: 'Start Recording',
+          accelerator: 'F9',
+          click: () => {
+            mainWindow.webContents.send('menu-start-recording');
+          }
+        },
+        {
+          label: 'Stop Recording',
+          accelerator: 'F10',
+          click: () => {
+            mainWindow.webContents.send('menu-stop-recording');
+          }
+        },
+        {
+          label: 'Pause/Resume',
+          accelerator: 'F8',
+          click: () => {
+            mainWindow.webContents.send('menu-pause-recording');
+          }
+        }
+      ]
+    },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' }
+      ]
+    },
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'About',
+          click: () => {
+            dialog.showMessageBox(mainWindow, {
+              type: 'info',
+              title: 'About Demo Recorder',
+              message: 'Demo Recorder v1.0.0',
+              detail: 'Free screen recording app for developers and teams\n\nBuilt with Electron and modern web technologies.'
+            });
+          }
+        }
+      ]
+    }
+  ];
+
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+}
+
+module.exports = buildMenu;

--- a/src/main/window.js
+++ b/src/main/window.js
@@ -1,0 +1,29 @@
+const { BrowserWindow } = require('electron');
+const path = require('path');
+const buildMenu = require('./menu');
+
+function createWindow(app) {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+      enableRemoteModule: true
+    },
+    icon: path.join(__dirname, '../../assets/icon.png'),
+    show: false
+  });
+
+  win.loadFile(path.join(__dirname, '../renderer/index.html'));
+
+  win.once('ready-to-show', () => {
+    win.show();
+  });
+
+  buildMenu(win, app);
+
+  return win;
+}
+
+module.exports = createWindow;


### PR DESCRIPTION
## Summary
- split Electron main process logic into separate modules
- update entry point to use new modules
- add basic Express backend service
- document new backend script
- include `express` dependency

## Testing
- `npm run backend` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68453568cfcc832587946a6764d75d61