### PR TITLE
Improve recording control state machine

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -154,7 +154,7 @@ button {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: #fa3c4c;
+  background: #b3b3b3;
   margin-right: 5px;
 }
 


### PR DESCRIPTION
## Summary
- implement recording state machine and timer handling in renderer.js
- disable/enable control buttons based on recording state
- hook menu events for start/pause/stop
- set idle status indicator color to grey

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684539d61f448325a9d808af732c4c39