### PR TITLE
Fix Windows build issues - Disable code signing and publishing to res…

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,11 @@
       "assets/**/*",
       "node_modules/**/*"
     ],
+    "publish": null,
     "win": {
       "target": "nsis",
-      "icon": "assets/icon.ico"
+      "icon": "assets/icon.ico",
+      "sign": null
     },
     "nsis": {
       "oneClick": false,


### PR DESCRIPTION
…olve symbolic link permissions error - Add sign: null and publish: null to package.json build config - Resolves electron-builder extraction failures on Windows