### PR TITLE
Implement menu actions

### DIFF
--- a/src/main/ipcHandlers.js
+++ b/src/main/ipcHandlers.js
@@ -1,4 +1,4 @@
-const { desktopCapturer, ipcMain, dialog, app, screen, globalShortcut } = require('electron');
+const { desktopCapturer, ipcMain, dialog, app, screen, globalShortcut, shell } = require('electron');
 const fs = require('fs');
 
 let recording = false;
@@ -56,6 +56,12 @@ function registerHandlers(window) {
 
   ipcMain.handle('get-app-version', () => {
     return app.getVersion();
+  });
+
+  ipcMain.handle('open-recordings-folder', async () => {
+    const dir = app.getPath('videos');
+    await shell.openPath(dir);
+    return dir;
   });
 
   ipcMain.on('recording-started', () => {

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -305,6 +305,35 @@ function setupIPCListeners() {
         logger.mouse('Global click IPC received:', clickData);
         mouseTracker.handleGlobalClick(clickData);
     });
+
+    // Menu actions from the native application menu
+    ipcRenderer.on('menu-start-recording', () => {
+        logger.ui('Menu triggered start recording');
+        startRecording();
+    });
+
+    ipcRenderer.on('menu-stop-recording', () => {
+        logger.ui('Menu triggered stop recording');
+        recordingStateMachine.stopRecording();
+    });
+
+    ipcRenderer.on('menu-pause-recording', () => {
+        logger.ui('Menu triggered pause/resume');
+        recordingStateMachine.pauseRecording();
+    });
+
+    ipcRenderer.on('menu-new-recording', () => {
+        logger.ui('Menu triggered new recording');
+        if (recordingStateMachine.getState().isRecording) {
+            recordingStateMachine.stopRecording();
+        }
+        window.location.reload();
+    });
+
+    ipcRenderer.on('menu-open-recordings', async () => {
+        logger.ui('Menu triggered open recordings folder');
+        await ipcRenderer.invoke('open-recordings-folder');
+    });
 }
 
 // --- Debug Functions ---


### PR DESCRIPTION
## Summary
- hook up native menu items to renderer actions
- support opening default videos folder

## Testing
- `npm run build` *(fails: electron-builder not found)*
- `npm run start` *(fails: electron not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465a0e3e248325988c26ba927bb44d